### PR TITLE
Update-MarkdowExtension-pymdownx.emoji

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,8 +54,8 @@ markdown_extensions:
   - pymdownx.mark
   - attr_list
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji 
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 copyright: |
   &copy; 2023 <a href="https://github.com/james-willett"  target="_blank" rel="noopener">James Willett</a>


### PR DESCRIPTION
Hello @james-willett 

I tried running the tutorial on your [YouTube](https://www.youtube.com/watch?v=Q-YA_dA8C20&list=WL&index=5) but this part of activating the emoji plugin didn't work. I searched the MKDOCS [documentation of emoji](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#emoji) and found a difference, it seems to be an update?